### PR TITLE
Support tables without geometries. Add options for returning geometries.

### DIFF
--- a/tifeatures/dbmodel.py
+++ b/tifeatures/dbmodel.py
@@ -70,7 +70,11 @@ class Table(BaseModel):
 
     def geometry_column(self, gcol: Optional[str] = None) -> Optional[GeometryColumn]:
         """Return the name of the first geometry column."""
-        if self.geometry_columns is not None and len(self.geometry_columns) > 0:
+        if (
+            self.geometry_columns is not None
+            and len(self.geometry_columns) > 0
+            and gcol != "none"
+        ):
             for c in self.geometry_columns:
                 if gcol is None or c.name == gcol:
                     return c

--- a/tifeatures/factory.py
+++ b/tifeatures/factory.py
@@ -346,7 +346,10 @@ class Endpoints:
                             ],
                         }
                     )
-                    for collection in [*tables, *list(function_catalog.values())]
+                    for collection in [
+                        *tables,
+                        *list(function_catalog.values()),
+                    ]
                 ],
             )
 
@@ -507,6 +510,13 @@ class Endpoints:
                 description="Starts the response at an offset.",
             ),
             output_type: Optional[ResponseType] = Depends(OutputType),
+            bbox_only: Optional[bool] = Query(
+                None,
+                description="Only return the bounding box of the feature.",
+            ),
+            simplify: Optional[float] = Query(
+                None, description="Simplify the output geometry."
+            ),
         ):
             offset = offset or 0
 
@@ -523,6 +533,8 @@ class Endpoints:
                 "datetime-column",
                 "limit",
                 "offset",
+                "bbox_only",
+                "simplify",
             ]
             properties_filter = [
                 (key, value)
@@ -542,6 +554,8 @@ class Endpoints:
                 offset=offset,
                 geom=geom_column,
                 dt=datetime_column,
+                bbox_only=bbox_only,
+                simplify=simplify,
             )
 
             qs = "?" + str(request.query_params) if request.query_params else ""


### PR DESCRIPTION
- Allows return of Features with no geometries
  - Return is still geojson with no geometry object - this is the precursor to regular json and csv formats for items.
  - Allows use of non-spatial tables
  - Allows "slim" data access removing the geometry information but still getting the attributes
- Add bbox_only parameter to items endpoint that returns only the bbox as the geometry for slimmer access where the entire geometry is not needed
- Add simplify parameter to items endpoint that runs st_snaptogrid(st_simplify(geom, <param>), <param>) to reduce the number of points and precision of the returned geometry.

TODO:
- [ ] Tests
- [ ] Changelog