### PR TITLE
add template configuration in Endpoint Factory

### DIFF
--- a/tifeatures/main.py
+++ b/tifeatures/main.py
@@ -1,5 +1,9 @@
 """tifeatures app."""
 
+from typing import Any, List
+
+import jinja2
+
 from tifeatures import __version__ as tifeatures_version
 from tifeatures.db import close_db_connection, connect_to_db, register_table_catalog
 from tifeatures.errors import DEFAULT_STATUS_CODES, add_exception_handlers
@@ -11,6 +15,7 @@ from tifeatures.settings import APISettings
 from fastapi import FastAPI
 
 from starlette.middleware.cors import CORSMiddleware
+from starlette.templating import Jinja2Templates
 from starlette_cramjam.middleware import CompressionMiddleware
 
 settings = APISettings()
@@ -22,8 +27,22 @@ app = FastAPI(
     docs_url="/api.html",
 )
 
+# custom template directory
+templates_location: List[Any] = (
+    [jinja2.FileSystemLoader(settings.template_directory)]
+    if settings.template_directory
+    else []
+)
+# default template directory
+templates_location.append(jinja2.PackageLoader(__package__, "templates"))
+
+templates = Jinja2Templates(
+    directory="",  # we need to set a dummy directory variable, see https://github.com/encode/starlette/issues/1214
+    loader=jinja2.ChoiceLoader(templates_location),
+)
+
 # Register endpoints.
-endpoints = Endpoints()
+endpoints = Endpoints(title=settings.name, templates=templates)
 app.include_router(endpoints.router)
 
 # We add the function registry to the application state


### PR DESCRIPTION
This PR removes call to APISettings (populated by environment variables)  in `tifeatures.factory.Endpoints` to enable more customization (template directories and title).