### PR TITLE
Fixes for Views and HTML geojson representation

### DIFF
--- a/tifeatures/filter/filters.py
+++ b/tifeatures/filter/filters.py
@@ -275,7 +275,6 @@ def attribute(name: str, fields: List[str]) -> V:
     if name in fields:
         return V(name)
     else:
-        print(name, fields)
         raise TypeError(f"Field {name} not in table.")
 
 

--- a/tifeatures/layer.py
+++ b/tifeatures/layer.py
@@ -134,7 +134,7 @@ class Table(CollectionLayer, DBTable):
         g = pg_funcs.cast(g, "geometry")
 
         if geometry_column.srid == 4326:
-            g = logic.Func("ST_Transform", g, 4326)
+            g = logic.Func("ST_Transform", g, pg_funcs.cast(4326, "int"))
 
         if bbox_only:
             g = logic.Func("ST_Envelope", g)

--- a/tifeatures/layer.py
+++ b/tifeatures/layer.py
@@ -336,7 +336,6 @@ class Table(CollectionLayer, DBTable):
         simplify: Optional[float] = None,
     ) -> Tuple[FeatureCollection, int]:
         """Build and run Pg query."""
-        print("id", self.id_column)
         if geom and geom.lower() != "none" and not self.geometry_column(geom):
             raise InvalidGeometryColumnName(f"Invalid Geometry Column: {geom}.")
 
@@ -394,7 +393,6 @@ class Table(CollectionLayer, DBTable):
             ),
             geom_columns=[g.name for g in self.geometry_columns],
         )
-        print(q, p)
         async with pool.acquire() as conn:
             items = await conn.fetchval(q, *p)
 

--- a/tifeatures/templates/item.html
+++ b/tifeatures/templates/item.html
@@ -31,7 +31,7 @@
 </div>
 
 <script>
-  var geojson = {{ response|safe }};
+  var geojson = {{ response|tojson }};
   var map = L.map('map').setView([0, 0], 1);
   map.addLayer(new L.TileLayer(
     'https://tile.openstreetmap.org/{z}/{x}/{y}.png', {

--- a/tifeatures/templates/items.html
+++ b/tifeatures/templates/items.html
@@ -80,7 +80,7 @@ $(function() {
   //
   // mapping
   //
-  var geojson = {{ response|safe }};
+  var geojson = {{ response|tojson }};
   var map = L.map('map').setView([0, 0], 1);
   map.addLayer(new L.TileLayer(
     'https://tile.openstreetmap.org/{z}/{x}/{y}.png', {


### PR DESCRIPTION
- Modify Database introspection to be work with views (fixes #33) 
  - The only issue with views is that introspection cannot determine which columns are unique / primary key columns. The introspection will use the first column with a name ending in 'id' if it exists and the first column otherwise. If that column is not unique, paging may not work well.
- Make sure that data casts work with geography columns (fixes #34)
- Fix issue with json casting to javascript in the html templates. Previously booleans and None were added to javascript as the pythonic True and None rather than json true and null. (fixes #35)
