### PR TITLE
ignore dropped attribute atttypid==0

### DIFF
--- a/tifeatures/dbmodel.py
+++ b/tifeatures/dbmodel.py
@@ -169,6 +169,7 @@ async def get_table_index(
                     WHERE
                         attnum>0
                         AND attrelid=c.oid
+                        AND NOT attisdropped
                 ) as columns,
                 (
                     SELECT


### PR DESCRIPTION
closes #47 

This PR adds a check in `get_table_index` to only get attribute with attisdropped

> attisdropped bool
> This column has been dropped and is no longer valid. A dropped column is still physically present in the table, but is ignored by the parser and so cannot be accessed via SQL.

https://www.postgresql.org/docs/current/catalog-pg-attribute.html